### PR TITLE
Refactor create config file

### DIFF
--- a/commands/file_operation_unix.go
+++ b/commands/file_operation_unix.go
@@ -1,0 +1,63 @@
+// +build !windows
+
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	FolderPermission = 0700 // only owner can read, write and execute
+	FilePermission   = 0600 // only owner can read and write
+)
+
+// createDefaultConfigFolderIfNotExists creates default config file along with folder if
+// it doesn't exists
+func createDefaultConfigFileIfNotExists() error {
+	defaultFilePath := GetDefaultConfigFilePath()
+	if isExists(defaultFilePath) {
+		return nil
+	}
+	folderPath := filepath.Dir(defaultFilePath)
+	if !isExists(folderPath) {
+		err := os.Mkdir(folderPath, FolderPermission)
+		if err != nil {
+			return err
+		}
+	}
+	f, err := os.Create(defaultFilePath)
+	if err != nil {
+		return err
+	}
+	if err = f.Chmod(FilePermission); err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func checkConfigFilePermission(configFilePath string) error {
+	//check for config file permission
+	info, err := os.Stat(configFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to get config file info due to: %w", err)
+	}
+	mode := info.Mode().Perm()
+
+	if mode != FilePermission {
+		return fmt.Errorf("permissions %o for '%s' are too open. It is required that your config file is NOT accessible by others", mode, configFilePath)
+	}
+	return nil
+}

--- a/commands/file_operation_windows.go
+++ b/commands/file_operation_windows.go
@@ -1,0 +1,25 @@
+// +build windows
+
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package commands
+
+import "fmt"
+
+func createDefaultConfigFileIfNotExists() error {
+	return fmt.Errorf("creating default config file is not supported for windows. Please create manually")
+}
+
+func checkConfigFilePermission(configFilePath string) error {
+	// since windows doesn't support create default config file, no validation is required
+	return nil
+}

--- a/commands/profile.go
+++ b/commands/profile.go
@@ -197,15 +197,8 @@ func getProfileController(cfgFlagValue string) (profile.Controller, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config file due to: %w", err)
 	}
-	//check for config file permission
-	info, err := os.Stat(configFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get config file info due to: %w", err)
-	}
-	mode := info.Mode().Perm()
-
-	if mode != FilePermission {
-		return nil, fmt.Errorf("permissions %o for '%s' are too open. It is required that your config file is NOT accessible by others", mode, configFilePath)
+	if err = checkConfigFilePermission(configFilePath); err != nil {
+		return nil, err
 	}
 	configController := config.New(configFilePath)
 	profileController := profile.New(configController)

--- a/commands/root.go
+++ b/commands/root.go
@@ -26,8 +26,6 @@ const (
 	defaultConfigFileName = "config"
 	flagConfig            = "config"
 	flagProfileName       = "profile"
-	FolderPermission      = 0700 // only owner can read, write and execute
-	FilePermission        = 0600 // only owner can read and write
 	ConfigEnvVarName      = "OPENSEARCH_CLI_CONFIG"
 	RootCommandName       = "opensearch-cli"
 	version               = "1.1.0"
@@ -94,30 +92,6 @@ func GetConfigFilePath(configFlagValue string) (string, error) {
 		return "", err
 	}
 	return GetDefaultConfigFilePath(), nil
-}
-
-// createDefaultConfigFolderIfNotExists creates default config file along with folder if
-// it doesn't exists
-func createDefaultConfigFileIfNotExists() error {
-	defaultFilePath := GetDefaultConfigFilePath()
-	if isExists(defaultFilePath) {
-		return nil
-	}
-	folderPath := filepath.Dir(defaultFilePath)
-	if !isExists(folderPath) {
-		err := os.Mkdir(folderPath, FolderPermission)
-		if err != nil {
-			return err
-		}
-	}
-	f, err := os.Create(defaultFilePath)
-	if err != nil {
-		return err
-	}
-	if err = f.Chmod(FilePermission); err != nil {
-		return err
-	}
-	return f.Close()
 }
 
 //isExists check if given path exists or not

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -77,7 +77,10 @@ func createTempConfigFile(testFilePath string) (*os.File, error) {
 		os.Remove(tmpfile.Name()) // clean up
 		return nil, err
 	}
-	if err := tmpfile.Chmod(FilePermission); err != nil {
+	if runtime.GOOS == "windows" {
+		return tmpfile, nil
+	}
+	if err := tmpfile.Chmod(0600); err != nil {
 		os.Remove(tmpfile.Name()) // clean up
 		return nil, err
 	}
@@ -139,6 +142,10 @@ func TestGetProfile(t *testing.T) {
 		assert.EqualError(t, err, "failed to get config file info due to: stat testdata/config1.yaml: no such file or directory", "unexpected error")
 	})
 	t.Run("invalid config file permission", func(t *testing.T) {
+
+		if runtime.GOOS == "windows" {
+			t.Skipf("test case does not work on %s", runtime.GOOS)
+		}
 		root := GetRoot()
 		assert.NotNil(t, root)
 		profileFile, err := createTempConfigFile("testdata/config.yaml")


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
chmod doesn't work for windows operating system. Hence, in windows
don't create default config file and check for permission. This will
let users responsible for creating their own config file and set
appropriate permission.
  
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-cli/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
