### PR TITLE
Format kNN test mappings

### DIFF
--- a/it/testdata/knn-sample-index-mapping
+++ b/it/testdata/knn-sample-index-mapping
@@ -1,8 +1,8 @@
 {
-"settings" : {
-  "number_of_shards" :   1,
-  "number_of_replicas" : 0,
-  "index.knn" : true
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0,
+    "index.knn": true
   },
   "mappings": {
     "properties": {
@@ -10,8 +10,8 @@
         "type": "knn_vector",
         "dimension": 2
       },
-      "color" : {
-        "type" : "keyword"
+      "color": {
+        "type": "keyword"
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Michael Lorant <michael.lorant@fairfaxmedia.com.au>

### Description
Fix formatting of kNN tests mapping file.
 
### Issues Resolved
Indenting was confusing and made it seem like `mappings` was a key under `settings` when they were at the same depth.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has documentation added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-cli/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
