### PR TITLE
Add support to check plugin is installed before running integration test

### DIFF
--- a/.github/workflows/integration-test-unreleased.yml
+++ b/.github/workflows/integration-test-unreleased.yml
@@ -9,7 +9,7 @@ on:
       - main
       - opensearch-*
 env:
-  OPENSEARCH_VERSION: '2.0'
+  OPENSEARCH_VERSION: '2.x'
 
 jobs:
   integ-test:
@@ -54,5 +54,4 @@ jobs:
         env:
           GOPROXY: "https://proxy.golang.org"
           OPENSEARCH_ENDPOINT: "http://localhost:9200"
-        run: |
-          go test -tags=integration ./it/platform/...
+        run: make test.integration.insecure

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
   integ-test:
     strategy:
       matrix:
-        opensearch-version: [ 1.0.1 , 1.1.0, 1.2.4, 1.3.1 ]
+        opensearch-version: [ 1.0.1 , 1.1.0, 1.2.4, 1.3.1, 2.0 ]
         go-version: [ 1.16.2 ]
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ test.integration:
 	go clean -testcache;
 	$(ENV_LOCAL_TEST) go test -tags=integration $(INTEGRATION_TEST_PATH);
 
+# this command will trigger integration test for cluster without security
+test.integration.insecure:
+	go clean -testcache;
+	OPENSEARCH_ENDPOINT="http://localhost:9200" go test -tags=integration $(INTEGRATION_TEST_PATH);
+
 test.unit:
 	go clean -testcache;
 	go test ./...;

--- a/it/ad_test.go
+++ b/it/ad_test.go
@@ -113,7 +113,7 @@ func (a *ADTestSuite) SetupSuite() {
 }
 
 func (a *ADTestSuite) TearDownSuite() {
-	if a.isPluginInstalled() == false {
+	if !a.IsPluginInstalled() {
 		return
 	}
 	a.DeleteIndex(EcommerceIndexName)
@@ -122,7 +122,7 @@ func (a *ADTestSuite) TearDownSuite() {
 // This will run right before the test starts
 // and receives the suite and test names as input
 func (a *ADTestSuite) BeforeTest(suiteName, testName string) {
-	if a.isPluginInstalled() == false {
+	if !a.IsPluginInstalled() {
 		return
 	}
 	// We don't need to create detector for create use case
@@ -134,7 +134,7 @@ func (a *ADTestSuite) BeforeTest(suiteName, testName string) {
 // This will run after test finishes
 // and receives the suite and test names as input
 func (a *ADTestSuite) AfterTest(suiteName, testName string) {
-	if a.isPluginInstalled() == false {
+	if !a.IsPluginInstalled() {
 		return
 	}
 	if testName != "TestCreateDetectors" || a.DetectorId != "" {
@@ -230,7 +230,7 @@ func getCreateDetectorRequest() adentity.CreateDetectorRequest {
 
 func (a *ADTestSuite) TestCreateDetectors() {
 	a.T().Run("create success", func(t *testing.T) {
-		if a.isPluginInstalled() == false {
+		if !a.IsPluginInstalled() {
 			t.Skipf("plugin %s is not installed", a.Plugins)
 		}
 		ctx := context.Background()
@@ -243,7 +243,7 @@ func (a *ADTestSuite) TestCreateDetectors() {
 }
 
 func (a *ADTestSuite) TestStopDetectors() {
-	if a.isPluginInstalled() == false {
+	if !a.IsPluginInstalled() {
 		a.T().Skipf("plugin %s is not installed", a.Plugins)
 	}
 	a.T().Run("stop success", func(t *testing.T) {
@@ -258,7 +258,7 @@ func (a *ADTestSuite) TestStopDetectors() {
 }
 
 func (a *ADTestSuite) TestStartDetectors() {
-	if a.isPluginInstalled() == false {
+	if !a.IsPluginInstalled() {
 		a.T().Skipf("plugin %s is not installed", a.Plugins)
 	}
 	a.T().Run("start success", func(t *testing.T) {
@@ -272,7 +272,7 @@ func (a *ADTestSuite) TestStartDetectors() {
 	})
 }
 func (a *ADTestSuite) TestDeleteDetectorsForce() {
-	if a.isPluginInstalled() == false {
+	if !a.IsPluginInstalled() {
 		a.T().Skipf("plugin %s is not installed", a.Plugins)
 	}
 	a.T().Run("delete force success", func(t *testing.T) {
@@ -287,7 +287,7 @@ func (a *ADTestSuite) TestDeleteDetectorsForce() {
 }
 
 func (a *ADTestSuite) TestDeleteDetectors() {
-	if a.isPluginInstalled() == false {
+	if !a.IsPluginInstalled() {
 		a.T().Skipf("plugin %s is not installed", a.Plugins)
 	}
 	a.T().Run("delete stopped success", func(t *testing.T) {
@@ -301,7 +301,7 @@ func (a *ADTestSuite) TestDeleteDetectors() {
 }
 
 func (a *ADTestSuite) TestGetDetectors() {
-	if a.isPluginInstalled() == false {
+	if !a.IsPluginInstalled() {
 		a.T().Skipf("plugin %s is not installed", a.Plugins)
 	}
 	a.T().Run("get detector success", func(t *testing.T) {
@@ -317,7 +317,7 @@ func (a *ADTestSuite) TestGetDetectors() {
 }
 
 func (a *ADTestSuite) TestUpdateDetectorsForce() {
-	if a.isPluginInstalled() == false {
+	if !a.IsPluginInstalled() {
 		a.T().Skipf("plugin %s is not installed", a.Plugins)
 	}
 	a.T().Run("update detector success", func(t *testing.T) {
@@ -351,7 +351,7 @@ func (a *ADTestSuite) TestUpdateDetectorsForce() {
 
 }
 func (a *ADTestSuite) TestUpdateDetectors() {
-	if a.isPluginInstalled() == false {
+	if !a.IsPluginInstalled() {
 		a.T().Skipf("plugin %s is not installed", a.Plugins)
 	}
 	a.T().Run("update detector success", func(t *testing.T) {

--- a/it/ad_test.go
+++ b/it/ad_test.go
@@ -64,6 +64,7 @@ func getRawFeatureAggregation() []byte {
 //SetupSuite runs once for every test suite
 func (a *ADTestSuite) SetupSuite() {
 	var err error
+	a.Plugins = append(a.Plugins, "opensearch-anomaly-detection")
 	a.Client, err = client.New(nil)
 	if err != nil {
 		fmt.Println(err)
@@ -112,12 +113,18 @@ func (a *ADTestSuite) SetupSuite() {
 }
 
 func (a *ADTestSuite) TearDownSuite() {
+	if a.isPluginInstalled() == false {
+		return
+	}
 	a.DeleteIndex(EcommerceIndexName)
 }
 
 // This will run right before the test starts
 // and receives the suite and test names as input
 func (a *ADTestSuite) BeforeTest(suiteName, testName string) {
+	if a.isPluginInstalled() == false {
+		return
+	}
 	// We don't need to create detector for create use case
 	if testName != "TestCreateDetectors" {
 		a.CreateDetectorUsingRESTAPI(a.T())
@@ -127,6 +134,9 @@ func (a *ADTestSuite) BeforeTest(suiteName, testName string) {
 // This will run after test finishes
 // and receives the suite and test names as input
 func (a *ADTestSuite) AfterTest(suiteName, testName string) {
+	if a.isPluginInstalled() == false {
+		return
+	}
 	if testName != "TestCreateDetectors" || a.DetectorId != "" {
 		a.StopDetectorUsingRESTAPI(a.T(), a.DetectorId)
 		a.DeleteDetectorUsingRESTAPI(a.T(), a.DetectorId)
@@ -220,6 +230,9 @@ func getCreateDetectorRequest() adentity.CreateDetectorRequest {
 
 func (a *ADTestSuite) TestCreateDetectors() {
 	a.T().Run("create success", func(t *testing.T) {
+		if a.isPluginInstalled() == false {
+			t.Skipf("plugin %s is not installed", a.Plugins)
+		}
 		ctx := context.Background()
 		ctrl := adctrl.New(os.Stdin, a.ESController, a.ADGateway)
 		response, err := ctrl.CreateAnomalyDetector(ctx, a.DetectorRequest)
@@ -230,6 +243,9 @@ func (a *ADTestSuite) TestCreateDetectors() {
 }
 
 func (a *ADTestSuite) TestStopDetectors() {
+	if a.isPluginInstalled() == false {
+		a.T().Skipf("plugin %s is not installed", a.Plugins)
+	}
 	a.T().Run("stop success", func(t *testing.T) {
 		a.StartDetectorUsingRESTAPI(t, a.DetectorId)
 		ctx := context.Background()
@@ -242,6 +258,9 @@ func (a *ADTestSuite) TestStopDetectors() {
 }
 
 func (a *ADTestSuite) TestStartDetectors() {
+	if a.isPluginInstalled() == false {
+		a.T().Skipf("plugin %s is not installed", a.Plugins)
+	}
 	a.T().Run("start success", func(t *testing.T) {
 		a.StopDetectorUsingRESTAPI(t, a.DetectorId)
 		ctx := context.Background()
@@ -253,6 +272,9 @@ func (a *ADTestSuite) TestStartDetectors() {
 	})
 }
 func (a *ADTestSuite) TestDeleteDetectorsForce() {
+	if a.isPluginInstalled() == false {
+		a.T().Skipf("plugin %s is not installed", a.Plugins)
+	}
 	a.T().Run("delete force success", func(t *testing.T) {
 		a.StartDetectorUsingRESTAPI(t, a.DetectorId)
 		ctx := context.Background()
@@ -265,6 +287,9 @@ func (a *ADTestSuite) TestDeleteDetectorsForce() {
 }
 
 func (a *ADTestSuite) TestDeleteDetectors() {
+	if a.isPluginInstalled() == false {
+		a.T().Skipf("plugin %s is not installed", a.Plugins)
+	}
 	a.T().Run("delete stopped success", func(t *testing.T) {
 		ctx := context.Background()
 		var stdin bytes.Buffer
@@ -276,6 +301,9 @@ func (a *ADTestSuite) TestDeleteDetectors() {
 }
 
 func (a *ADTestSuite) TestGetDetectors() {
+	if a.isPluginInstalled() == false {
+		a.T().Skipf("plugin %s is not installed", a.Plugins)
+	}
 	a.T().Run("get detector success", func(t *testing.T) {
 		ctx := context.Background()
 		var stdin bytes.Buffer
@@ -289,6 +317,9 @@ func (a *ADTestSuite) TestGetDetectors() {
 }
 
 func (a *ADTestSuite) TestUpdateDetectorsForce() {
+	if a.isPluginInstalled() == false {
+		a.T().Skipf("plugin %s is not installed", a.Plugins)
+	}
 	a.T().Run("update detector success", func(t *testing.T) {
 		a.StartDetectorUsingRESTAPI(t, a.DetectorId)
 		ctx := context.Background()
@@ -320,6 +351,9 @@ func (a *ADTestSuite) TestUpdateDetectorsForce() {
 
 }
 func (a *ADTestSuite) TestUpdateDetectors() {
+	if a.isPluginInstalled() == false {
+		a.T().Skipf("plugin %s is not installed", a.Plugins)
+	}
 	a.T().Run("update detector success", func(t *testing.T) {
 		ctx := context.Background()
 		ctrl := adctrl.New(os.Stdin, a.ESController, a.ADGateway)

--- a/it/helper.go
+++ b/it/helper.go
@@ -119,7 +119,8 @@ func (a *CLISuite) callRequest(method string, reqBytes []byte, url string) ([]by
 	return ioutil.ReadAll(response.Body)
 }
 
-func (a *CLISuite) isPluginInstalled() bool {
+// isPluginInstalled checks whether dependent plugins are insalled or not
+func (a *CLISuite) IsPluginInstalled() bool {
 	pluginListsInBytes, err := a.callRequest(http.MethodGet, []byte(""), fmt.Sprintf("%s/%s", a.Profile.Endpoint, getPluginNamesURL))
 	if err != nil {
 		fmt.Println(err)
@@ -128,7 +129,7 @@ func (a *CLISuite) isPluginInstalled() bool {
 	pluginListsAsString := string(pluginListsInBytes[:])
 	pluginArray := strings.Split(pluginListsAsString, newLine)
 	for _, plugin := range a.Plugins {
-		if contains(pluginArray, plugin) == false {
+		if !contains(pluginArray, plugin) {
 			return false
 		}
 	}

--- a/it/helper.go
+++ b/it/helper.go
@@ -121,6 +121,11 @@ func (a *CLISuite) callRequest(method string, reqBytes []byte, url string) ([]by
 
 // isPluginInstalled checks whether dependent plugins are insalled or not
 func (a *CLISuite) IsPluginInstalled() bool {
+	return a.IsPluginFromInputInstalled(a.Plugins)
+}
+
+// IsPluginFromInputInstalled checks whether input plugins are insalled or not
+func (a *CLISuite) IsPluginFromInputInstalled(plugins []string) bool {
 	pluginListsInBytes, err := a.callRequest(http.MethodGet, []byte(""), fmt.Sprintf("%s/%s", a.Profile.Endpoint, getPluginNamesURL))
 	if err != nil {
 		fmt.Println(err)
@@ -128,7 +133,7 @@ func (a *CLISuite) IsPluginInstalled() bool {
 	}
 	pluginListsAsString := string(pluginListsInBytes[:])
 	pluginArray := strings.Split(pluginListsAsString, newLine)
-	for _, plugin := range a.Plugins {
+	for _, plugin := range plugins {
 		if !contains(pluginArray, plugin) {
 			return false
 		}

--- a/it/knn_test.go
+++ b/it/knn_test.go
@@ -61,6 +61,7 @@ func (a *KNNTestSuite) SetupSuite() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	a.Plugins = append(a.Plugins, "opensearch-knn")
 	a.Gateway, _ = gateway.New(a.Client, a.Profile)
 	a.Controller = ctrl.New(a.Gateway)
 	a.CreateIndex(KNNSampleIndexFileName, KnnSampleIndexMappingFileName)
@@ -80,6 +81,9 @@ func (a *KNNTestSuite) GetNodesIDUsingRESTAPI(t *testing.T) string {
 }
 
 func (a *KNNTestSuite) TestGetStatistics() {
+	if a.isPluginInstalled() == false {
+		a.T().Skipf("plugin %s is not installed", a.Plugins)
+	}
 	a.T().Run("test get full stats", func(t *testing.T) {
 		ctx := context.Background()
 		response, err := a.Controller.GetStatistics(ctx, "", "")
@@ -161,6 +165,9 @@ func (a *KNNTestSuite) TestGetStatistics() {
 }
 
 func (a *KNNTestSuite) TestWarmupIndices() {
+	if a.isPluginInstalled() == false {
+		a.T().Skipf("plugin %s is not installed", a.Plugins)
+	}
 	a.T().Run("test warmup success", func(t *testing.T) {
 		ctx := context.Background()
 		response, err := a.Controller.WarmupIndices(ctx, []string{KNNSampleIndexFileName})

--- a/it/knn_test.go
+++ b/it/knn_test.go
@@ -81,7 +81,7 @@ func (a *KNNTestSuite) GetNodesIDUsingRESTAPI(t *testing.T) string {
 }
 
 func (a *KNNTestSuite) TestGetStatistics() {
-	if a.isPluginInstalled() == false {
+	if !a.IsPluginInstalled() {
 		a.T().Skipf("plugin %s is not installed", a.Plugins)
 	}
 	a.T().Run("test get full stats", func(t *testing.T) {
@@ -165,7 +165,7 @@ func (a *KNNTestSuite) TestGetStatistics() {
 }
 
 func (a *KNNTestSuite) TestWarmupIndices() {
-	if a.isPluginInstalled() == false {
+	if !a.IsPluginInstalled() {
 		a.T().Skipf("plugin %s is not installed", a.Plugins)
 	}
 	a.T().Run("test warmup success", func(t *testing.T) {


### PR DESCRIPTION
### Description
opensearch-cli workflows contains both released docker images and assembled docker image from OpenSearch
repository. In order to provide one test suite for integration test, added support to mention the plugin names are pre-requisite for test to be executed. If any of the plugin is not installed, the tests will be skipped.
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-cli/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
