### PR TITLE
fix help message of profile create command

### DIFF
--- a/commands/profile.go
+++ b/commands/profile.go
@@ -174,7 +174,7 @@ func init() {
 	_ = createProfileCmd.MarkFlagRequired(FlagProfileCreateName)
 	createProfileCmd.Flags().StringP(FlagProfileCreateEndpoint, "e", "", "Create profile with this endpoint or host")
 	_ = createProfileCmd.MarkFlagRequired(FlagProfileCreateEndpoint)
-	createProfileCmd.Flags().StringP(FlagProfileCreateAuthType, "a", "", "Authentication type. Options are disabled, basic and aws-iam."+
+	createProfileCmd.Flags().StringP(FlagProfileCreateAuthType, "a", "", "Authentication type. Options are disabled, basic, cert and aws-iam."+
 		"\nIf security is disabled, provide --auth-type='disabled'.\nIf security uses HTTP basic authentication, provide --auth-type='basic'.\n"+
 		"If security uses client certificate authentication, provide --auth-type='cert'.\n"+
 		"If security uses AWS IAM ARNs as users, provide --auth-type='aws-iam'.\nopensearch-cli asks for additional information based on your choice of authentication type.")


### PR DESCRIPTION
Signed-off-by: michimani <michimani210@gmail.com>

### Description
This PR corrects a message in the help for the `profile create` command. Specifically, the `--auth-type` flag was missing a description of `cert`.
 
### Issues Resolved
None
 
### Check List
- ~~[ ] New functionality includes testing.~~
  - ~~[ ] All tests pass~~
- ~~[ ] New functionality has been documented.~~
  - ~~[ ] New functionality has documentation added~~
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-cli/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
