### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,10 +1,13 @@
-# OpenSearch CLI Maintainers
+## Overview
 
-## Maintainers
-| Maintainer | GitHub ID | Affiliation |
-| --------------- | --------- | ----------- |
-| Charlotte | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
-| Jack Mazanec| [jmazanec15](https://github.com/jmazanec15) | Amazon |
-| Nick Knize | [nknize](https://github.com/nknize) | Amazon |
-| Vamshi Vijay Nakkirtha | [vamshin](https://github.com/vamshin) | Amazon |
-| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB) | Amazon |
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
+
+| Maintainer              | GitHub ID                                   | Affiliation |
+| ----------------------- | ------------------------------------------- | ----------- |
+| Charlotte               | [CEHENKLE](https://github.com/CEHENKLE)     | Amazon      |
+| Jack Mazanec            | [jmazanec15](https://github.com/jmazanec15) | Amazon      |
+| Nick Knize              | [nknize](https://github.com/nknize)         | Amazon      |
+| Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)       | Amazon      |
+| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)     | Amazon      |


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.