### PR TITLE
refactor: remove io/ioutil dependency

### DIFF
--- a/commands/profile_test.go
+++ b/commands/profile_test.go
@@ -14,7 +14,6 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"opensearch-cli/controller/profile/mocks"
 	"opensearch-cli/entity"
 	"os"
@@ -95,7 +94,7 @@ func TestCreateProfile(t *testing.T) {
 		assert.EqualErrorf(t, err, "required flag(s) \"auth-type\", \"endpoint\", \"name\" not set", "unexpected error")
 	})
 	t.Run("create security disabled profile", func(t *testing.T) {
-		f, err := ioutil.TempFile("", "profile")
+		f, err := os.CreateTemp("", "profile")
 		assert.NoError(t, err)
 		defer func() {
 			err := os.Remove(f.Name())
@@ -116,7 +115,7 @@ func TestCreateProfile(t *testing.T) {
 		})
 		_, err = root.ExecuteC()
 		assert.NoError(t, err)
-		contents, _ := ioutil.ReadFile(f.Name())
+		contents, _ := os.ReadFile(f.Name())
 		var actual entity.Config
 		assert.NoError(t, yaml.Unmarshal(contents, &actual))
 		retryVal := 2
@@ -135,7 +134,7 @@ func TestCreateProfile(t *testing.T) {
 
 func TestDeleteProfileCommand(t *testing.T) {
 	t.Run("test delete profile command", func(t *testing.T) {
-		f, err := ioutil.TempFile("", "profile-delete")
+		f, err := os.CreateTemp("", "profile-delete")
 		assert.NoError(t, err)
 		defer func() {
 			err := os.Remove(f.Name())
@@ -144,7 +143,7 @@ func TestDeleteProfileCommand(t *testing.T) {
 		config := entity.Config{Profiles: []entity.Profile{fakeInputProfile()}}
 		bytes, err := yaml.Marshal(config)
 		assert.NoError(t, err)
-		assert.NoError(t, ioutil.WriteFile(f.Name(), bytes, 0644))
+		assert.NoError(t, os.WriteFile(f.Name(), bytes, 0644))
 		assert.NoError(t, f.Sync())
 		root := GetRoot()
 		assert.NotNil(t, root)
@@ -155,7 +154,7 @@ func TestDeleteProfileCommand(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, expected, f.Name())
 		var expectedConfig entity.Config
-		contents, err := ioutil.ReadFile(f.Name())
+		contents, err := os.ReadFile(f.Name())
 		assert.NoError(t, err)
 		err = yaml.Unmarshal(contents, &expectedConfig)
 		assert.NoError(t, err)
@@ -165,7 +164,7 @@ func TestDeleteProfileCommand(t *testing.T) {
 
 func TestListsProfileCommand(t *testing.T) {
 	t.Run("list profiles", func(t *testing.T) {
-		f, err := ioutil.TempFile("", "profile-list")
+		f, err := os.CreateTemp("", "profile-list")
 		assert.NoError(t, err)
 		defer func() {
 			err := os.Remove(f.Name())
@@ -174,7 +173,7 @@ func TestListsProfileCommand(t *testing.T) {
 		config := entity.Config{Profiles: []entity.Profile{fakeInputProfile()}}
 		bytes, err := yaml.Marshal(config)
 		assert.NoError(t, err)
-		assert.NoError(t, ioutil.WriteFile(f.Name(), bytes, 0644))
+		assert.NoError(t, os.WriteFile(f.Name(), bytes, 0644))
 		assert.NoError(t, f.Sync())
 		root := GetRoot()
 		assert.NotNil(t, root)
@@ -186,7 +185,7 @@ func TestListsProfileCommand(t *testing.T) {
 		assert.EqualValues(t, expected, f.Name())
 	})
 	t.Run("list profiles with verbose", func(t *testing.T) {
-		f, err := ioutil.TempFile("", "profile-list")
+		f, err := os.CreateTemp("", "profile-list")
 		assert.NoError(t, err)
 		defer func() {
 			err := os.Remove(f.Name())
@@ -195,7 +194,7 @@ func TestListsProfileCommand(t *testing.T) {
 		config := entity.Config{Profiles: []entity.Profile{fakeInputProfile()}}
 		bytes, err := yaml.Marshal(config)
 		assert.NoError(t, err)
-		assert.NoError(t, ioutil.WriteFile(f.Name(), bytes, 0644))
+		assert.NoError(t, os.WriteFile(f.Name(), bytes, 0644))
 		assert.NoError(t, f.Sync())
 		root := GetRoot()
 		assert.NotNil(t, root)
@@ -207,7 +206,7 @@ func TestListsProfileCommand(t *testing.T) {
 		assert.EqualValues(t, expected, f.Name())
 	})
 	t.Run("no profiles found", func(t *testing.T) {
-		f, err := ioutil.TempFile("", "profile")
+		f, err := os.CreateTemp("", "profile")
 		assert.NoError(t, err)
 		defer func() {
 			err := os.Remove(f.Name())
@@ -216,7 +215,7 @@ func TestListsProfileCommand(t *testing.T) {
 		config := entity.Config{Profiles: []entity.Profile{}}
 		bytes, err := yaml.Marshal(config)
 		assert.NoError(t, err)
-		assert.NoError(t, ioutil.WriteFile(f.Name(), bytes, 0644))
+		assert.NoError(t, os.WriteFile(f.Name(), bytes, 0644))
 		assert.NoError(t, f.Sync())
 		root := GetRoot()
 		assert.NotNil(t, root)

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -12,7 +12,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"opensearch-cli/entity"
 	"os"
 	"path/filepath"
@@ -65,11 +64,11 @@ func TestVersionString(t *testing.T) {
 }
 
 func createTempConfigFile(testFilePath string) (*os.File, error) {
-	content, err := ioutil.ReadFile(testFilePath)
+	content, err := os.ReadFile(testFilePath)
 	if err != nil {
 		return nil, err
 	}
-	tmpfile, err := ioutil.TempFile(os.TempDir(), "test-file")
+	tmpfile, err := os.CreateTemp(os.TempDir(), "test-file")
 	if err != nil {
 		return nil, err
 	}

--- a/controller/ad/ad_test.go
+++ b/controller/ad/ad_test.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	mockController "opensearch-cli/controller/platform/mocks"
 	entity "opensearch-cli/entity/ad"
 	gateway "opensearch-cli/gateway/ad/mocks"
@@ -35,7 +34,7 @@ const mockDetectorName = "detector"
 
 func helperLoadBytes(t *testing.T, name string) []byte {
 	path := filepath.Join("testdata", name) // relative path
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/controller/config/config.go
+++ b/controller/config/config.go
@@ -12,7 +12,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"opensearch-cli/entity"
 	"os"
 
@@ -29,9 +28,9 @@ type controller struct {
 	path string
 }
 
-//Read deserialize config file into entity.Config
+// Read deserialize config file into entity.Config
 func (c controller) Read() (result entity.Config, err error) {
-	contents, err := ioutil.ReadFile(c.path)
+	contents, err := os.ReadFile(c.path)
 	if err != nil {
 		return
 	}
@@ -39,7 +38,7 @@ func (c controller) Read() (result entity.Config, err error) {
 	return
 }
 
-//Write serialize entity.Config into file path
+// Write serialize entity.Config into file path
 func (c controller) Write(config entity.Config) (err error) {
 	file, err := os.Create(c.path) //overwrite if file exists
 	if err != nil {
@@ -59,7 +58,7 @@ func (c controller) Write(config entity.Config) (err error) {
 	return file.Sync()
 }
 
-//New returns config controller instance
+// New returns config controller instance
 func New(path string) Controller {
 	return controller{
 		path: path,

--- a/controller/config/config_test.go
+++ b/controller/config/config_test.go
@@ -13,7 +13,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"opensearch-cli/entity"
 	"os"
 	"path/filepath"
@@ -60,7 +59,7 @@ func TestControllerRead(t *testing.T) {
 }
 func TestControllerWrite(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		f, err := ioutil.TempFile("", "config")
+		f, err := os.CreateTemp("", "config")
 		assert.NoError(t, err)
 		defer func() {
 			err = os.Remove(f.Name())
@@ -69,7 +68,7 @@ func TestControllerWrite(t *testing.T) {
 		ctrl := New(f.Name())
 		err = ctrl.Write(getSampleConfig())
 		assert.NoError(t, err)
-		contents, err := ioutil.ReadFile(f.Name())
+		contents, err := os.ReadFile(f.Name())
 		assert.NoError(t, err)
 		var config entity.Config
 		err = yaml.Unmarshal(contents, &config)

--- a/controller/platform/platform_test.go
+++ b/controller/platform/platform_test.go
@@ -14,10 +14,10 @@ package platform
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"opensearch-cli/entity/platform"
 	"opensearch-cli/gateway/platform/mocks"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -27,7 +27,7 @@ import (
 
 func helperLoadBytes(t *testing.T, name string) []byte {
 	path := filepath.Join("testdata", name) // relative path
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/docs/dev/tutorial.md
+++ b/docs/dev/tutorial.md
@@ -309,7 +309,7 @@ func (h *Handler) CreateAnomalyDetector(fileName string) error {
 			fmt.Println("failed to close json:", err)
 		}
 	}()
-	byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := io.ReadAll(jsonFile)
 	var request entity.CreateDetectorRequest
 	err = json.Unmarshal(byteValue, &request)
 	if err != nil {

--- a/entity/platform/request_error.go
+++ b/entity/platform/request_error.go
@@ -15,18 +15,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 )
 
-//RequestError contains more information that can be used by client to provide
-//better error message
+// RequestError contains more information that can be used by client to provide
+// better error message
 type RequestError struct {
 	statusCode int
 	err        error
 	response   []byte
 }
 
-//NewRequestError builds RequestError
+// NewRequestError builds RequestError
 func NewRequestError(statusCode int, body io.ReadCloser, err error) *RequestError {
 	return &RequestError{
 		statusCode: statusCode,
@@ -35,17 +34,17 @@ func NewRequestError(statusCode int, body io.ReadCloser, err error) *RequestErro
 	}
 }
 
-//Error inherits error interface to pass as error
+// Error inherits error interface to pass as error
 func (r *RequestError) Error() string {
 	return r.err.Error()
 }
 
-//StatusCode to get response's status code
+// StatusCode to get response's status code
 func (r *RequestError) StatusCode() int {
 	return r.statusCode
 }
 
-//GetResponse to get error response from OpenSearch
+// GetResponse to get error response from OpenSearch
 func (r *RequestError) GetResponse() string {
 	var data map[string]interface{}
 	if err := json.Unmarshal(r.response, &data); err != nil {
@@ -55,9 +54,9 @@ func (r *RequestError) GetResponse() string {
 	return string(formattedResponse)
 }
 
-//getResponseBody to extract response body from OpenSearch server
+// getResponseBody to extract response body from OpenSearch server
 func getResponseBody(b io.Reader) []byte {
-	resBytes, err := ioutil.ReadAll(b)
+	resBytes, err := io.ReadAll(b)
 	if err != nil {
 		fmt.Println("failed to read response")
 	}

--- a/gateway/ad/ad_test.go
+++ b/gateway/ad/ad_test.go
@@ -15,12 +15,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"opensearch-cli/client"
 	"opensearch-cli/client/mocks"
 	"opensearch-cli/entity"
 	"opensearch-cli/entity/ad"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,7 +30,7 @@ import (
 
 func helperLoadBytes(t *testing.T, name string) []byte {
 	path := filepath.Join("testdata", name) // relative path
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +46,7 @@ func getTestClient(t *testing.T, response string, code int, method string, actio
 		return &http.Response{
 			StatusCode: code,
 			// Send response to be tested
-			Body: ioutil.NopCloser(bytes.NewBufferString(response)),
+			Body: io.NopCloser(bytes.NewBufferString(response)),
 			// Must be set to non-nil value or it panics
 			Header:  make(http.Header),
 			Status:  "SOME OUTPUT",
@@ -231,7 +232,7 @@ func getSearchClient(t *testing.T, responseData []byte, code int) *client.Client
 		// Test request parameters
 		assert.Equal(t, req.URL.String(), "http://localhost:9200/_plugins/_anomaly_detection/detectors/_search")
 		assert.EqualValues(t, req.Method, http.MethodPost)
-		resBytes, _ := ioutil.ReadAll(req.Body)
+		resBytes, _ := io.ReadAll(req.Body)
 		var body ad.SearchRequest
 		err := json.Unmarshal(resBytes, &body)
 		assert.NoError(t, err)
@@ -240,7 +241,7 @@ func getSearchClient(t *testing.T, responseData []byte, code int) *client.Client
 		return &http.Response{
 			StatusCode: code,
 			// Send response to be tested
-			Body: ioutil.NopCloser(bytes.NewBufferString(string(responseData))),
+			Body: io.NopCloser(bytes.NewBufferString(string(responseData))),
 			// Must be set to non-nil value or it panics
 			Header:  make(http.Header),
 			Status:  "SOME OUTPUT",
@@ -288,7 +289,7 @@ func getCreateClient(t *testing.T, responseData []byte, code int) *client.Client
 		// Test request parameters
 		assert.Equal(t, req.URL.String(), "http://localhost:9200/_plugins/_anomaly_detection/detectors")
 		assert.EqualValues(t, req.Method, http.MethodPost)
-		resBytes, _ := ioutil.ReadAll(req.Body)
+		resBytes, _ := io.ReadAll(req.Body)
 		var body ad.CreateDetector
 		err := json.Unmarshal(resBytes, &body)
 		assert.NoError(t, err)
@@ -297,7 +298,7 @@ func getCreateClient(t *testing.T, responseData []byte, code int) *client.Client
 		return &http.Response{
 			StatusCode: code,
 			// Send response to be tested
-			Body: ioutil.NopCloser(bytes.NewBufferString(string(responseData))),
+			Body: io.NopCloser(bytes.NewBufferString(string(responseData))),
 			// Must be set to non-nil value or it panics
 			Header:  make(http.Header),
 			Status:  "SOME OUTPUT",

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -61,7 +60,7 @@ func GetTLSConfig(trust *entity.Trust) (*tls.Config, error) {
 	}
 	caCertPool := x509.NewCertPool()
 	if trust.CAFilePath != nil {
-		caCert, err := ioutil.ReadFile(*trust.CAFilePath)
+		caCert, err := os.ReadFile(*trust.CAFilePath)
 		if err != nil {
 			return nil, fmt.Errorf("error opening certificate file %s, error: %s", *trust.CAFilePath, err)
 		}
@@ -164,7 +163,7 @@ func (g *HTTPGateway) Execute(req *retryablehttp.Request) ([]byte, error) {
 	if err = g.isValidResponse(response); err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(response.Body)
+	return io.ReadAll(response.Body)
 }
 
 // Call calls request using http and return error if status code is not expected

--- a/gateway/knn/knn_test.go
+++ b/gateway/knn/knn_test.go
@@ -15,7 +15,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"opensearch-cli/client"
 	"opensearch-cli/client/mocks"
@@ -34,7 +34,7 @@ func getTestClient(t *testing.T, url string, code int, response []byte) *client.
 		return &http.Response{
 			StatusCode: code,
 			// Send response to be tested
-			Body: ioutil.NopCloser(bytes.NewBuffer(response)),
+			Body: io.NopCloser(bytes.NewBuffer(response)),
 			// Must be set to non-nil value or it panics
 			Header:  make(http.Header),
 			Status:  "SOME OUTPUT",

--- a/gateway/platform/platform_test.go
+++ b/gateway/platform/platform_test.go
@@ -15,12 +15,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"opensearch-cli/client"
 	"opensearch-cli/client/mocks"
 	"opensearch-cli/entity"
 	"opensearch-cli/entity/platform"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,7 +30,7 @@ import (
 
 func helperLoadBytes(t *testing.T, name string) []byte {
 	path := filepath.Join("testdata", name) // relative path
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +41,7 @@ func getTestClient(t *testing.T, responseData string, code int) *client.Client {
 	return mocks.NewTestClient(func(req *http.Request) *http.Response {
 		// Test request parameters
 		assert.Equal(t, req.URL.String(), "http://localhost:9200/test_index/_search")
-		resBytes, _ := ioutil.ReadAll(req.Body)
+		resBytes, _ := io.ReadAll(req.Body)
 		var body platform.SearchRequest
 		err := json.Unmarshal(resBytes, &body)
 		assert.NoError(t, err)
@@ -50,7 +51,7 @@ func getTestClient(t *testing.T, responseData string, code int) *client.Client {
 		return &http.Response{
 			StatusCode: code,
 			// Send response to be tested
-			Body: ioutil.NopCloser(bytes.NewBufferString(responseData)),
+			Body: io.NopCloser(bytes.NewBufferString(responseData)),
 			// Must be set to non-nil value or it panics
 			Header:  make(http.Header),
 			Status:  "SOME OUTPUT",
@@ -63,7 +64,7 @@ func getCurlTestClient(t *testing.T, expectedURL string, expectedData []byte, ex
 	return mocks.NewTestClient(func(req *http.Request) *http.Response {
 		// Test request parameters
 		assert.Equal(t, expectedURL, req.URL.String())
-		resBytes, _ := ioutil.ReadAll(req.Body)
+		resBytes, _ := io.ReadAll(req.Body)
 		assert.EqualValues(t, expectedData, resBytes)
 
 		for k, v := range expectedHeader {
@@ -72,7 +73,7 @@ func getCurlTestClient(t *testing.T, expectedURL string, expectedData []byte, ex
 		return &http.Response{
 			StatusCode: code,
 			// Send response to be tested
-			Body: ioutil.NopCloser(bytes.NewBufferString(responseData)),
+			Body: io.NopCloser(bytes.NewBufferString(responseData)),
 			// Must be set to non-nil value or it panics
 			Header:  make(http.Header),
 			Status:  "SOME OUTPUT",

--- a/handler/ad/ad.go
+++ b/handler/ad/ad.go
@@ -15,14 +15,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"opensearch-cli/controller/ad"
 	entity "opensearch-cli/entity/ad"
 	"opensearch-cli/mapper"
 	"os"
 )
 
-//Handler is facade for controller
+// Handler is facade for controller
 type Handler struct {
 	ad.Controller
 }
@@ -34,12 +34,12 @@ func New(controller ad.Controller) *Handler {
 	}
 }
 
-//CreateAnomalyDetector creates detector based on file configurations
+// CreateAnomalyDetector creates detector based on file configurations
 func CreateAnomalyDetector(h *Handler, fileName string) error {
 	return h.CreateAnomalyDetector(fileName)
 }
 
-//GenerateAnomalyDetector generate sample detector to provide skeleton for users
+// GenerateAnomalyDetector generate sample detector to provide skeleton for users
 func GenerateAnomalyDetector() ([]byte, error) {
 	return json.MarshalIndent(entity.CreateDetectorRequest{
 		Name:        "Detector Name",
@@ -61,7 +61,7 @@ func GenerateAnomalyDetector() ([]byte, error) {
 	}, "", "  ")
 }
 
-//CreateAnomalyDetector creates detector based on file configurations
+// CreateAnomalyDetector creates detector based on file configurations
 func (h *Handler) CreateAnomalyDetector(fileName string) error {
 	if len(fileName) < 1 {
 		return fmt.Errorf("file name cannot be empty")
@@ -77,7 +77,7 @@ func (h *Handler) CreateAnomalyDetector(fileName string) error {
 			fmt.Println("failed to close json:", err)
 		}
 	}()
-	byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := io.ReadAll(jsonFile)
 	var request entity.CreateDetectorRequest
 	err = json.Unmarshal(byteValue, &request)
 	if err != nil {
@@ -96,12 +96,12 @@ func (h *Handler) CreateAnomalyDetector(fileName string) error {
 	return err
 }
 
-//DeleteAnomalyDetectorByID deletes detector based on detectorId
+// DeleteAnomalyDetectorByID deletes detector based on detectorId
 func DeleteAnomalyDetectorByID(h *Handler, detectorID string, force bool) error {
 	return h.DeleteAnomalyDetectorByID(detectorID, force)
 }
 
-//DeleteAnomalyDetectorByID deletes detector based on detectorId
+// DeleteAnomalyDetectorByID deletes detector based on detectorId
 func (h *Handler) DeleteAnomalyDetectorByID(detectorID string, force bool) error {
 
 	ctx := context.Background()
@@ -112,12 +112,12 @@ func (h *Handler) DeleteAnomalyDetectorByID(detectorID string, force bool) error
 	return err
 }
 
-//DeleteAnomalyDetectorByNamePattern deletes detector based on detectorName
+// DeleteAnomalyDetectorByNamePattern deletes detector based on detectorName
 func DeleteAnomalyDetectorByNamePattern(h *Handler, detectorName string, force bool) error {
 	return h.DeleteAnomalyDetectorByNamePattern(detectorName, force)
 }
 
-//DeleteAnomalyDetectorByNamePattern deletes detector based on detectorName
+// DeleteAnomalyDetectorByNamePattern deletes detector based on detectorName
 func (h *Handler) DeleteAnomalyDetectorByNamePattern(detectorName string, force bool) error {
 
 	ctx := context.Background()
@@ -128,12 +128,12 @@ func (h *Handler) DeleteAnomalyDetectorByNamePattern(detectorName string, force 
 	return err
 }
 
-//StartAnomalyDetectorByID starts detector based on detector id
+// StartAnomalyDetectorByID starts detector based on detector id
 func StartAnomalyDetectorByID(h *Handler, detector string) error {
 	return h.StartAnomalyDetectorByID(detector)
 }
 
-//StartAnomalyDetectorByID starts detector based on detector id
+// StartAnomalyDetectorByID starts detector based on detector id
 func (h *Handler) StartAnomalyDetectorByID(detector string) error {
 
 	ctx := context.Background()
@@ -224,7 +224,7 @@ func (h *Handler) GetAnomalyDetectorByID(name string) (*entity.DetectorOutput, e
 	return detector, nil
 }
 
-//UpdateDetector updates detector based on file configurations
+// UpdateDetector updates detector based on file configurations
 func (h *Handler) UpdateDetector(fileName string, force bool, start bool) error {
 	if len(fileName) < 1 {
 		return fmt.Errorf("file name cannot be empty")
@@ -240,7 +240,7 @@ func (h *Handler) UpdateDetector(fileName string, force bool, start bool) error 
 			fmt.Println("failed close json file due to ", err)
 		}
 	}()
-	byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := io.ReadAll(jsonFile)
 	var request entity.UpdateDetectorUserInput
 	err = json.Unmarshal(byteValue, &request)
 	if err != nil {

--- a/it/helper.go
+++ b/it/helper.go
@@ -15,7 +15,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"opensearch-cli/client"
 	"opensearch-cli/entity"
@@ -40,10 +40,10 @@ type CLISuite struct {
 	Plugins []string
 }
 
-//HelperLoadBytes loads file from testdata and stream contents
+// HelperLoadBytes loads file from testdata and stream contents
 func HelperLoadBytes(name string) []byte {
 	path := filepath.Join("testdata", name) // relative path
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -74,7 +74,7 @@ func (a *CLISuite) ValidateProfile() error {
 	return nil
 }
 
-//CreateIndex creates test data for plugin processing
+// CreateIndex creates test data for plugin processing
 func (a *CLISuite) CreateIndex(indexFileName string, mappingFileName string) {
 	if mappingFileName != "" {
 		mapping, err := a.callRequest(
@@ -116,7 +116,7 @@ func (a *CLISuite) callRequest(method string, reqBytes []byte, url string) ([]by
 			return
 		}
 	}()
-	return ioutil.ReadAll(response.Body)
+	return io.ReadAll(response.Body)
 }
 
 // isPluginInstalled checks whether dependent plugins are insalled or not

--- a/mapper/ad/ad_test.go
+++ b/mapper/ad/ad_test.go
@@ -12,9 +12,9 @@
 package ad
 
 import (
-	"io/ioutil"
 	"opensearch-cli/entity/ad"
 	"opensearch-cli/mapper"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -23,7 +23,7 @@ import (
 
 func helperLoadBytes(t *testing.T, name string) []byte {
 	path := filepath.Join("testdata", name) // relative path
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mapper/platform/platform.go
+++ b/mapper/platform/platform.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"opensearch-cli/entity/platform"
 	"os"
@@ -142,7 +141,7 @@ func toCurlPayload(data string) (payload []byte, err error) {
 	}
 	// if data is file name, read file contents
 	if strings.HasPrefix(data, FileNameIdentifier) && !isEmpty(strings.TrimPrefix(data, FileNameIdentifier)) {
-		return ioutil.ReadFile(data[1:])
+		return os.ReadFile(data[1:])
 	}
 	// if data is invalid json string
 	if !json.Valid([]byte(data)) {

--- a/mapper/platform/platform_test.go
+++ b/mapper/platform/platform_test.go
@@ -12,9 +12,9 @@
 package platform
 
 import (
-	"io/ioutil"
 	"net/http"
 	"opensearch-cli/entity/platform"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -22,7 +22,7 @@ import (
 
 func helperLoadBytes(t *testing.T, name string) []byte {
 	path := filepath.Join("testdata", name) // relative path
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Description
io/ioutil has been deprecated since Go 1.16
https://pkg.go.dev/io/ioutil

adding `hacktoberfest` label would be much appreciated :)
 

### Issues Resolved
n/a
 
### Check List
- [n/a] New functionality includes testing.
  - [x] All tests pass
- [n/a] New functionality has been documented.
  - [n/a] New functionality has documentation added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-cli/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
