### PR TITLE
Update build and release script

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,11 +33,15 @@ builds:
         goarch: 386
 archives:
   -
-    name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    replacements:
-      darwin: macos
-      386: x86
-      amd64: x64
+    name_template: >-
+      {{- .ProjectName }}-
+      {{- .Version }}-
+      {{- .Os }}-
+      {{- if eq .Arch "amd64" }}x64
+      {{- else if eq .Arch "386" }}x86
+      {{- else if eq .Arch "darwin" }}macos
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
     files:
       - none*
     format_overrides:

--- a/release/build.sh
+++ b/release/build.sh
@@ -24,7 +24,7 @@ echo 'setting cli version'
 export VERSION="1.2.0"
 
 echo 'Generating artifacts'
-goreleaser --snapshot --skip-publish --rm-dist
+goreleaser --snapshot --skip-publish --clean
 
 # goreleaser generates folder and binary too. Remove unwanted files to keep only
 # relevant files inside dist folder


### PR DESCRIPTION
### Description
Came across this when we started the release: GoReleaser removed archives.replacements field https://goreleaser.com/deprecations/#archivesreplacements - so it needs to be updated to new format.

Also replacing --rm-dist with --clean for goreleaser command.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4185
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-cli/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
